### PR TITLE
Updated version for rave in dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "process"
   ],
   "peerDependencies": {
-    "rave": "~0.1"
+    "rave": "~0.4"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
rave-node-process and rave-load-jsx had different rave versions as dependency and this extension works well with 0.4
